### PR TITLE
Update README tool icons and clean up layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,36 +73,32 @@
 
 <h3 align="center">🚀 Programming, Test Automation & Frameworks</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=java,typescript,selenium,cypress,playwright,maven" alt="Programming and automation tools" />
+  <img src="https://skillicons.dev/icons?i=java,ts,playwright,selenium,cypress,maven&perline=10" alt="Programming, test automation and frameworks" />
 </p>
 
 <h3 align="center">📡 API, Backend Testing & Observability</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=postman,mysql,grafana" alt="API and backend testing tools" />
+  <img src="https://skillicons.dev/icons?i=postman,mysql,grafana&perline=10" alt="API, backend testing and observability" />
 </p>
 
 <h3 align="center">♿ Accessibility & UX Testing</h3>
 <p align="center">
-  <a href="https://wave.webaim.org/" target="_blank"><img src="https://www.inclusionhub.com/hubfs/WAVE%20logomark.jpg" alt="WAVE Accessibility Tool" width="40" height="40"/></a>
+  <img src="https://skillicons.dev/icons?i=webflow&perline=10" alt="Accessibility and UX testing" />
 </p>
 
-<!-- 🧪 Performance & Mobile Testing -->
 <h3 align="center">🧪 Performance & Mobile Testing</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=appium" alt="Mobile testing" />
-  <a href="https://locust.io/" target="_blank"><img src="https://locust.io/static/img/favicon.ico" alt="Locust" width="40" height="40"/></a>
+  <img src="https://skillicons.dev/icons?i=appium&perline=10" alt="Performance and mobile testing" />
 </p>
 
 <h3 align="center">💻 IDE & CI/CD</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=vscode,idea,github,jenkins" alt="IDE and CI/CD tools" />
+  <img src="https://skillicons.dev/icons?i=vscode,idea,github,jenkins&perline=10" alt="IDE and CI/CD" />
 </p>
 
 <h3 align="center">🤝 Collaboration & DevOps</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=git,github,bitbucket,jira,slack" alt="Collaboration and DevOps tools" />
-  <a href="https://www.microsoft.com/microsoft-teams" target="_blank"><img src="https://cdn.jim-nielsen.com/ios/512/microsoft-teams-2019-05-31.png?rf=1024" alt="Microsoft Teams" width="40" height="40"/></a>
-  <a href="https://mattermost.com/" target="_blank" rel="noreferrer"><img src="https://play-lh.googleusercontent.com/jmZcnjbtWkX1l143bqxz2DZqnrVUSJvGikocCb8znsXYJCIJkoZmvJknJn8MQKgMdkw=w240-h480-rw" alt="Mattermost" width="40" height="40"/></a>
+  <img src="https://skillicons.dev/icons?i=git,github,bitbucket,jira,slack,discord&perline=10" alt="Collaboration and DevOps" />
 </p>
 
 <hr>
@@ -144,4 +140,3 @@
 <h2 align="center">Keep coding! 💻 Stay awesome! ✨</h2>
 
 <hr>
-

--- a/README.md
+++ b/README.md
@@ -75,31 +75,61 @@
 <p align="center">
   <img src="https://skillicons.dev/icons?i=java,ts,playwright,selenium,cypress,maven&perline=10" alt="Programming, test automation and frameworks" />
 </p>
+<table align="center">
+  <tr>
+    <td><img src="https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_c40984fae76060168e91322094f05421/cucumber.png" alt="Cucumber" width="34" height="34"/></td>
+    <td><img src="https://browserstack.wpengine.com/wp-content/uploads/2024/01/JUnit5-icon.svg" alt="JUnit" width="34" height="34"/></td>
+    <td><img src="https://www.pcloudy.com/wp-content/uploads/2021/03/7.jpg" alt="TestNG" width="34" height="34"/></td>
+    <td><img src="https://www.javacodegeeks.com/wp-content/uploads/2012/10/apache-poi-logo.jpg" alt="Apache POI" width="34" height="34"/></td>
+  </tr>
+</table>
 
 <h3 align="center">📡 API, Backend Testing & Observability</h3>
 <p align="center">
   <img src="https://skillicons.dev/icons?i=postman,mysql,grafana&perline=10" alt="API, backend testing and observability" />
 </p>
+<table align="center">
+  <tr>
+    <td><img src="https://openmoji.org/data/color/svg/1F436.svg" alt="Bruno" width="34" height="34"/></td>
+    <td><img src="https://avatars.githubusercontent.com/u/19369327?s=280&v=4" alt="Rest Assured" width="34" height="34"/></td>
+    <td><img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR9GlozyrEsA25S68xqsWEgejZkSQPi2L7SBw&s" alt="Swagger" width="34" height="34"/></td>
+    <td><img src="https://www.pgadmin.org/static/COMPILED/assets/img/logo-hero.png" alt="pgAdmin4" width="34" height="34"/></td>
+    <td><img src="https://www.jobscoupe.com/wp-content/uploads/2019/08/Java-JDBC.jpg" alt="JDBC" width="34" height="34"/></td>
+    <td><img src="https://www.ucyfer.com/wp-content/uploads/2023/01/logo-splunk.jpeg" alt="Splunk" width="34" height="34"/></td>
+  </tr>
+</table>
 
 <h3 align="center">♿ Accessibility & UX Testing</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=webflow&perline=10" alt="Accessibility and UX testing" />
+  <img src="https://www.inclusionhub.com/hubfs/WAVE%20logomark.jpg" alt="WAVE Accessibility Tool" width="40" height="40"/>
 </p>
 
 <h3 align="center">🧪 Performance & Mobile Testing</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=appium&perline=10" alt="Performance and mobile testing" />
+  <img src="https://skillicons.dev/icons?i=appium&perline=10" alt="Appium" />
+  <img src="https://locust.io/static/img/favicon.ico" alt="Locust" width="40" height="40"/>
 </p>
 
 <h3 align="center">💻 IDE & CI/CD</h3>
 <p align="center">
   <img src="https://skillicons.dev/icons?i=vscode,idea,github,jenkins&perline=10" alt="IDE and CI/CD" />
 </p>
+<p align="center">
+  <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQJ171TqGq21JDajxZwUYBqX9m8zN7SZsMVew&s" alt="GitHub Copilot" width="40" height="40"/>
+</p>
 
 <h3 align="center">🤝 Collaboration & DevOps</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=git,github,bitbucket,jira,slack,discord&perline=10" alt="Collaboration and DevOps" />
+  <img src="https://skillicons.dev/icons?i=git,github,bitbucket,jira,slack&perline=10" alt="Collaboration and DevOps" />
 </p>
+<table align="center">
+  <tr>
+    <td><img src="https://is4-ssl.mzstatic.com/image/thumb/Purple123/v4/7d/de/96/7dde9601-aeb7-7ce6-9141-d0664014b017/source/60x60bb.jpg" alt="Jira Xray" width="34" height="34"/></td>
+    <td><img src="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fyt3.ggpht.com%2F-52BLU4E8lho%2FAAAAAAAAAAI%2FAAAAAAAAAAA%2FL0tsY_BFH74%2Fs900-c-k-no-mo-rj-c0xffffff%2Fphoto.jpg&f=1&nofb=1&ipt=803242248bece5b82554610c83bbc2627f97eee6b63a31a62a3605b738aa4557" alt="Jira Zephyr" width="34" height="34"/></td>
+    <td><img src="https://cdn.jim-nielsen.com/ios/512/microsoft-teams-2019-05-31.png?rf=1024" alt="Microsoft Teams" width="34" height="34"/></td>
+    <td><img src="https://play-lh.googleusercontent.com/jmZcnjbtWkX1l143bqxz2DZqnrVUSJvGikocCb8znsXYJCIJkoZmvJknJn8MQKgMdkw=w240-h480-rw" alt="Mattermost" width="34" height="34"/></td>
+  </tr>
+</table>
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -75,61 +75,37 @@
 <p align="center">
   <img src="https://skillicons.dev/icons?i=java,ts,playwright,selenium,cypress,maven&perline=10" alt="Programming, test automation and frameworks" />
 </p>
-<table align="center">
-  <tr>
-    <td><img src="https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_c40984fae76060168e91322094f05421/cucumber.png" alt="Cucumber" width="34" height="34"/></td>
-    <td><img src="https://browserstack.wpengine.com/wp-content/uploads/2024/01/JUnit5-icon.svg" alt="JUnit" width="34" height="34"/></td>
-    <td><img src="https://www.pcloudy.com/wp-content/uploads/2021/03/7.jpg" alt="TestNG" width="34" height="34"/></td>
-    <td><img src="https://www.javacodegeeks.com/wp-content/uploads/2012/10/apache-poi-logo.jpg" alt="Apache POI" width="34" height="34"/></td>
-  </tr>
-</table>
+<p align="center"><sub>Also: Cucumber • JUnit • TestNG • Apache POI</sub></p>
 
 <h3 align="center">📡 API, Backend Testing & Observability</h3>
 <p align="center">
   <img src="https://skillicons.dev/icons?i=postman,mysql,grafana&perline=10" alt="API, backend testing and observability" />
 </p>
-<table align="center">
-  <tr>
-    <td><img src="https://openmoji.org/data/color/svg/1F436.svg" alt="Bruno" width="34" height="34"/></td>
-    <td><img src="https://avatars.githubusercontent.com/u/19369327?s=280&v=4" alt="Rest Assured" width="34" height="34"/></td>
-    <td><img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR9GlozyrEsA25S68xqsWEgejZkSQPi2L7SBw&s" alt="Swagger" width="34" height="34"/></td>
-    <td><img src="https://www.pgadmin.org/static/COMPILED/assets/img/logo-hero.png" alt="pgAdmin4" width="34" height="34"/></td>
-    <td><img src="https://www.jobscoupe.com/wp-content/uploads/2019/08/Java-JDBC.jpg" alt="JDBC" width="34" height="34"/></td>
-    <td><img src="https://www.ucyfer.com/wp-content/uploads/2023/01/logo-splunk.jpeg" alt="Splunk" width="34" height="34"/></td>
-  </tr>
-</table>
+<p align="center"><sub>Also: Bruno • Rest Assured • Swagger • pgAdmin4 • JDBC • Splunk</sub></p>
 
 <h3 align="center">♿ Accessibility & UX Testing</h3>
 <p align="center">
-  <img src="https://www.inclusionhub.com/hubfs/WAVE%20logomark.jpg" alt="WAVE Accessibility Tool" width="40" height="40"/>
+  <img src="https://skillicons.dev/icons?i=webflow&perline=10" alt="Accessibility and UX testing" />
 </p>
+<p align="center"><sub>Also: WAVE Accessibility Tool</sub></p>
 
 <h3 align="center">🧪 Performance & Mobile Testing</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=appium&perline=10" alt="Appium" />
-  <img src="https://locust.io/static/img/favicon.ico" alt="Locust" width="40" height="40"/>
+  <img src="https://skillicons.dev/icons?i=appium&perline=10" alt="Performance and mobile testing" />
 </p>
+<p align="center"><sub>Also: Locust</sub></p>
 
 <h3 align="center">💻 IDE & CI/CD</h3>
 <p align="center">
   <img src="https://skillicons.dev/icons?i=vscode,idea,github,jenkins&perline=10" alt="IDE and CI/CD" />
 </p>
-<p align="center">
-  <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQJ171TqGq21JDajxZwUYBqX9m8zN7SZsMVew&s" alt="GitHub Copilot" width="40" height="40"/>
-</p>
+<p align="center"><sub>Also: GitHub Copilot</sub></p>
 
 <h3 align="center">🤝 Collaboration & DevOps</h3>
 <p align="center">
   <img src="https://skillicons.dev/icons?i=git,github,bitbucket,jira,slack&perline=10" alt="Collaboration and DevOps" />
 </p>
-<table align="center">
-  <tr>
-    <td><img src="https://is4-ssl.mzstatic.com/image/thumb/Purple123/v4/7d/de/96/7dde9601-aeb7-7ce6-9141-d0664014b017/source/60x60bb.jpg" alt="Jira Xray" width="34" height="34"/></td>
-    <td><img src="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fyt3.ggpht.com%2F-52BLU4E8lho%2FAAAAAAAAAAI%2FAAAAAAAAAAA%2FL0tsY_BFH74%2Fs900-c-k-no-mo-rj-c0xffffff%2Fphoto.jpg&f=1&nofb=1&ipt=803242248bece5b82554610c83bbc2627f97eee6b63a31a62a3605b738aa4557" alt="Jira Zephyr" width="34" height="34"/></td>
-    <td><img src="https://cdn.jim-nielsen.com/ios/512/microsoft-teams-2019-05-31.png?rf=1024" alt="Microsoft Teams" width="34" height="34"/></td>
-    <td><img src="https://play-lh.googleusercontent.com/jmZcnjbtWkX1l143bqxz2DZqnrVUSJvGikocCb8znsXYJCIJkoZmvJknJn8MQKgMdkw=w240-h480-rw" alt="Mattermost" width="34" height="34"/></td>
-  </tr>
-</table>
+<p align="center"><sub>Also: Jira Xray • Jira Zephyr • Microsoft Teams • Mattermost</sub></p>
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -73,39 +73,62 @@
 
 <h3 align="center">🚀 Programming, Test Automation & Frameworks</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=java,ts,playwright,selenium,cypress,maven&perline=10" alt="Programming, test automation and frameworks" />
+  <a href="https://www.java.com" target="_blank"><img src="https://cdn-icons-png.flaticon.com/512/226/226777.png" style="margin:5px;" alt="Java" width="40" height="40"/></a>
+  <a href="https://www.typescriptlang.org/" target="_blank"><img src="https://cdn.worldvectorlogo.com/logos/typescript.svg" style="margin:5px;" alt="TypeScript" width="40" height="40"/></a>
+  <a href="https://playwright.dev" target="_blank"><img src="https://playwright.dev/img/playwright-logo.svg" style="margin:5px;" alt="Playwright" width="40" height="40"/></a>
+  <a href="https://www.selenium.dev" target="_blank"><img src="https://www.selenium.dev/images/selenium_logo_square_green.png" style="margin:5px;" alt="Selenium" width="40" height="40"/></a>
+  <a href="https://www.cypress.io" target="_blank"><img src="https://user-images.githubusercontent.com/2801156/153322291-8b186487-5127-48f7-aa6d-b0ef350f8575.png" style="margin:5px;" alt="Cypress" width="40" height="40"/></a>
+  <a href="https://cucumber.io/" target="_blank"><img src="https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_c40984fae76060168e91322094f05421/cucumber.png" style="margin:5px;" alt="Cucumber" width="40" height="40"/></a>
+  <a href="https://junit.org/junit5/" target="_blank"><img src="https://browserstack.wpengine.com/wp-content/uploads/2024/01/JUnit5-icon.svg" style="margin:5px;" alt="JUnit" width="40" height="40"/></a>
+  <a href="https://testng.org/doc/" target="_blank"><img src="https://www.pcloudy.com/wp-content/uploads/2021/03/7.jpg" style="margin:5px;" alt="TestNG" width="40" height="40"/></a>
+  <a href="https://poi.apache.org/" target="_blank"><img src="https://www.javacodegeeks.com/wp-content/uploads/2012/10/apache-poi-logo.jpg" style="margin:5px;" alt="ApachePOI" width="40" height="40"/></a>
+  <a href="https://maven.apache.org/" target="_blank"><img src="https://e7.pngegg.com/pngimages/968/16/png-clipart-apache-maven-apache-ant-gradle-apache-http-server-apache-ivy-apache-maven-text-orange-thumbnail.png" style="margin:5px;" alt="Maven" width="40" height="40"/></a>
 </p>
-<p align="center"><sub>Also: Cucumber • JUnit • TestNG • Apache POI</sub></p>
 
 <h3 align="center">📡 API, Backend Testing & Observability</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=postman,mysql,grafana&perline=10" alt="API, backend testing and observability" />
+  <a href="https://postman.com" target="_blank"><img src="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.K66TNl9EFGiJ68QlP48hGwHaHa%26pid%3DApi" style="margin:5px;" alt="Postman" width="40" height="40"/></a>
+  <a href="https://www.usebruno.com/" target="_blank"><img src="https://openmoji.org/data/color/svg/1F436.svg" style="margin:5px;" alt="Bruno" width="40" height="40"/></a>  
+  <a href="https://rest-assured.io/" target="_blank"><img src="https://avatars.githubusercontent.com/u/19369327?s=280&v=4" style="margin:5px;" alt="Rest Assured" width="40" height="40"/></a>
+  <a href="https://swagger.io/tools/swagger-ui/" target="_blank"><img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR9GlozyrEsA25S68xqsWEgejZkSQPi2L7SBw&s" style="margin:5px;" alt="Swagger" width="40" height="40"/></a>
+  <a href="https://www.mysql.com/" target="_blank"><img src="https://pngimg.com/uploads/mysql/mysql_PNG9.png" style="margin:5px;" alt="MySQL" width="40" height="40"/></a>
+  <a href="https://www.pgadmin.org/" target="_blank"><img src="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%2Fid%2FOIP.Q7VvPa7HsW3m768GDQw7zQHaHa%3Fpid%3DApi&f=1&ipt=ffba928385f39d009a0d41e5a52f23068b3cfb7cb63c0a7eb9c79de8791f2d1a" style="margin:5px;" alt="pgAdmin4" width="40" height="40"/></a>
+  <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/" target="_blank"><img src="https://www.jobscoupe.com/wp-content/uploads/2019/08/Java-JDBC.jpg" style="margin:5px;" alt="JDBC" width="40" height="40"/></a>
+  <a href="https://grafana.com/" target="_blank"><img src="https://cdn.worldvectorlogo.com/logos/grafana.svg" style="margin:5px;" alt="Grafana" width="40" height="40"/></a>
+  <a href="https://www.splunk.com/" target="_blank"><img src="https://www.ucyfer.com/wp-content/uploads/2023/01/logo-splunk.jpeg" style="margin:5px;" alt="Splunk" width="40" height="40"/></a>
 </p>
-<p align="center"><sub>Also: Bruno • Rest Assured • Swagger • pgAdmin4 • JDBC • Splunk</sub></p>
 
 <h3 align="center">♿ Accessibility & UX Testing</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=webflow&perline=10" alt="Accessibility and UX testing" />
+	<a href="https://wave.webaim.org/" target="_blank"><img src="https://www.inclusionhub.com/hubfs/WAVE%20logomark.jpg" style="margin:5px;" alt="WAVE Accessibility Tool" width="40" height="40"/></a>
 </p>
-<p align="center"><sub>Also: WAVE Accessibility Tool</sub></p>
 
 <h3 align="center">🧪 Performance & Mobile Testing</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=appium&perline=10" alt="Performance and mobile testing" />
+  <a href="http://appium.io/docs/en/2.0/" target="_blank"><img src="https://e7.pngegg.com/pngimages/372/674/png-clipart-appium-test-automation-software-testing-selenium-calabash-purple-violet-thumbnail.png" alt="Appium" width="40" height="40"/></a>
+  <a href="https://locust.io/" target="_blank"><img src="https://locust.io/static/img/favicon.ico" alt="Locust" width="40" height="40"/></a>
 </p>
-<p align="center"><sub>Also: Locust</sub></p>
 
 <h3 align="center">💻 IDE & CI/CD</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=vscode,idea,github,jenkins&perline=10" alt="IDE and CI/CD" />
+  <a href="https://code.visualstudio.com/" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/9/9a/Visual_Studio_Code_1.35_icon.svg" style="margin:5px;" alt="VSCode" width="40" height="40"/></a>
+  <a href="https://www.jetbrains.com/idea/" target="_blank"><img src="https://brandslogos.com/wp-content/uploads/images/large/intellij-idea-logo.png" style="margin:5px;" alt="IntelliJ IDEA" width="40" height="40"/></a>
+  <a href="https://github.com/features/copilot" target="_blank"><img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQJ171TqGq21JDajxZwUYBqX9m8zN7SZsMVew&s" style="margin:5px;" alt="GitHub Copilot" width="40" height="40"/></a>
+  <a href="https://www.jenkins.io" target="_blank"><img src="https://www.vectorlogo.zone/logos/jenkins/jenkins-icon.svg" style="margin:5px;" alt="Jenkins" width="40" height="40"/></a>
 </p>
-<p align="center"><sub>Also: GitHub Copilot</sub></p>
 
 <h3 align="center">🤝 Collaboration & DevOps</h3>
 <p align="center">
-  <img src="https://skillicons.dev/icons?i=git,github,bitbucket,jira,slack&perline=10" alt="Collaboration and DevOps" />
+  <a href="https://git-scm.com/" target="_blank"><img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" style="margin:5px;" alt="Git" width="40" height="40"/></a>
+  <a href="https://github.com/" target="_blank"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" style="margin:5px;" alt="GitHub" width="40" height="40"/></a>
+  <a href="https://bitbucket.org/" target="_blank"><img src="https://icon-library.com/images/bitbucket-icon/bitbucket-icon-28.jpg" style="margin:5px;" alt="Bitbucket" width="40" height="40"/></a>
+  <a href="https://www.atlassian.com/software/jira" target="_blank"><img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/jira/jira-original-wordmark.svg" style="margin:5px;" alt="Jira" width="40" height="40"/></a>
+  <a href="https://marketplace.atlassian.com/apps/1211769/xray-test-management-for-jira" target="_blank"><img src="https://is4-ssl.mzstatic.com/image/thumb/Purple123/v4/7d/de/96/7dde9601-aeb7-7ce6-9141-d0664014b017/source/60x60bb.jpg" style="margin:5px;" alt="Jira Xray" width="40" height="40"/></a>
+  <a href="https://marketplace.atlassian.com/apps/1213259/zephyr-scale-test-management-for-jira" target="_blank"><img src="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fyt3.ggpht.com%2F-52BLU4E8lho%2FAAAAAAAAAAI%2FAAAAAAAAAAA%2FL0tsY_BFH74%2Fs900-c-k-no-mo-rj-c0xffffff%2Fphoto.jpg&f=1&nofb=1&ipt=803242248bece5b82554610c83bbc2627f97eee6b63a31a62a3605b738aa4557" style="margin:5px;" alt="Jira Zephyr" width="40" height="40"/></a>
+  <a href="https://slack.com/intl/en-tr/" target="_blank"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/Slack_icon_2019.svg/2048px-Slack_icon_2019.svg.png" style="margin:5px;" alt="Slack" width="40" height="40"/></a>
+  <a href="https://www.microsoft.com/microsoft-teams" target="_blank"><img src="https://cdn.jim-nielsen.com/ios/512/microsoft-teams-2019-05-31.png?rf=1024" style="margin:5px;" alt="Microsoft Teams" width="40" height="40"/></a>
+  <a href="https://mattermost.com/" target="_blank" rel="noreferrer"><img src="https://play-lh.googleusercontent.com/jmZcnjbtWkX1l143bqxz2DZqnrVUSJvGikocCb8znsXYJCIJkoZmvJknJn8MQKgMdkw=w240-h480-rw" style="margin:5px;" alt="Mattermost" width="40" height="40"/></a>
 </p>
-<p align="center"><sub>Also: Jira Xray • Jira Zephyr • Microsoft Teams • Mattermost</sub></p>
 
 <hr>
 


### PR DESCRIPTION
 Standardize and refresh the tools/tech sections in the README by moving to `skillicons.dev` icons, simplifying icon layout, and tidying up accessibility and collaboration entries.